### PR TITLE
Add messaging for a locked user

### DIFF
--- a/app/code/community/HE/TwoFactorAuth/Model/Observer.php
+++ b/app/code/community/HE/TwoFactorAuth/Model/Observer.php
@@ -305,7 +305,12 @@ class HE_TwoFactorAuth_Model_Observer
             }
             // If an admin is logged in and the user is locked, we force a logout action
             $this->_forceAdminUserLogout();
-            return;
+            Mage::getModel('core/cookie')->set("admin_user_locked", 1);
+            $lockInfo = $observer->getEvent()->getLockInfo();
+            if ($lockInfo) {
+                $lockInfo->setData("is_locked", true);
+            }
+            return $this;
         }
 
         if ($observer->getEvent()->getName() == "admin_session_user_login_failed") {
@@ -317,5 +322,12 @@ class HE_TwoFactorAuth_Model_Observer
         $resource = Mage::getResourceSingleton('enterprise_pci/admin_user');
         $resource->unlock($observer->getEvent()->getUser()->getId());
         return;
+    }
+
+    public function adminhtmlBlockHtmlBefore(Varien_Event_Observer $observer)
+    {
+         if(Mage::getModel('core/cookie')->get("admin_user_locked")) {
+              Mage::getModel('core/cookie')->delete("admin_user_locked");
+         }
     }
 }

--- a/app/code/community/HE/TwoFactorAuth/Model/Observer.php
+++ b/app/code/community/HE/TwoFactorAuth/Model/Observer.php
@@ -323,11 +323,4 @@ class HE_TwoFactorAuth_Model_Observer
         $resource->unlock($observer->getEvent()->getUser()->getId());
         return;
     }
-
-    public function adminhtmlBlockHtmlBefore(Varien_Event_Observer $observer)
-    {
-         if(Mage::getModel('core/cookie')->get("admin_user_locked")) {
-              Mage::getModel('core/cookie')->delete("admin_user_locked");
-         }
-    }
 }

--- a/app/code/community/HE/TwoFactorAuth/Model/Observer.php
+++ b/app/code/community/HE/TwoFactorAuth/Model/Observer.php
@@ -305,9 +305,9 @@ class HE_TwoFactorAuth_Model_Observer
             }
             // If an admin is logged in and the user is locked, we force a logout action
             $this->_forceAdminUserLogout();
-            Mage::getModel('core/cookie')->set("admin_user_locked", 1);
             $lockInfo = $observer->getEvent()->getLockInfo();
             if ($lockInfo) {
+                // update lock info value, for the event dispatching controller to display error message
                 $lockInfo->setData("is_locked", true);
             }
             return $this;

--- a/app/code/community/HE/TwoFactorAuth/controllers/Adminhtml/TwofactorController.php
+++ b/app/code/community/HE/TwoFactorAuth/controllers/Adminhtml/TwofactorController.php
@@ -157,8 +157,6 @@ class HE_TwoFactorAuth_Adminhtml_TwofactorController extends Mage_Adminhtml_Cont
                 ->setActionName('login')
                 ->setDispatched(false);
         } else {
-            $msg = Mage::helper('he_twofactorauth')->__("Valid code entered");
-            Mage::getSingleton('adminhtml/session')->addSuccess($msg);
             $this->_redirect('*');
         }
 
@@ -232,8 +230,6 @@ class HE_TwoFactorAuth_Adminhtml_TwofactorController extends Mage_Adminhtml_Cont
                             ->setActionName('login')
                             ->setDispatched(false);
                     } else {
-                        $msg = Mage::helper('he_twofactorauth')->__("Valid code entered");
-                        Mage::getSingleton('adminhtml/session')->addSuccess($msg);
                         $this->_redirect('*');
                     }
 


### PR DESCRIPTION
#342501

Previously, a message was not displayed to the user, when signing in with a locked account

![image](https://user-images.githubusercontent.com/13652158/28478124-fc1c57fa-6e24-11e7-8d72-d8abdf7c5d1c.png)
