### PR TITLE
Fix continue on google qr code scan

### DIFF
--- a/app/design/adminhtml/default/default/template/he_twofactor/google/auth.phtml
+++ b/app/design/adminhtml/default/default/template/he_twofactor/google/auth.phtml
@@ -97,10 +97,10 @@
                 <div class="clear"></div>
                 <div class="form-buttons">
                     <a class="left" href="<?php echo $this->getUrl('adminhtml/index/logout'); ?>">&laquo; <?php echo Mage::helper('adminhtml')->__('Log Out'); ?></a>
-                    
-                    <?php if (!empty($qr_url)) { ?>                    
-                        <button class="forgot-password" onclick="loginForm.submit()" type="button"><span><span><span><?php echo Mage::helper('adminhtml')->__('Continue'); // TODO need better/clearer wording here? ?></span></span></span></button>
-                    
+
+                    <?php if (!empty($qr_url)) { ?>
+                        <button class="forgot-password" type="submit"><span><span><span><?php echo Mage::helper('adminhtml')->__('Continue'); // TODO need better/clearer wording here? ?></span></span></span></button>
+
                     <?php } else { ?>
                        
                         <button class="forgot-password" onclick="loginForm.submit()" type="button"><span><span><span><?php echo Mage::helper('adminhtml')->__('Submit Code'); ?></span></span></span></button>


### PR DESCRIPTION
There is a known magento bug, that causes the continue button to not work on a forgot password

Apparently this is fixed by removing the onclick submit and changing the button type

This may mean, we are skipping validation

But this is the screen to read the 2FA code... not much validation to perform