### PR TITLE
Per Admin User Exclude and More

### DIFF
--- a/app/code/community/HE/TwoFactorAuth/Helper/Trusted.php
+++ b/app/code/community/HE/TwoFactorAuth/Helper/Trusted.php
@@ -27,6 +27,10 @@ class HE_TwoFactorAuth_Helper_Trusted extends Mage_Core_Helper_Abstract
     {
         return Mage::getStoreConfig('he2faconfig/control/trusted_device');
     }
+
+    public function getTrustedTime() {
+        return Mage::getStoreConfig('he2faconfig/control/trusted_device_duration');
+    }
 }
 
 ?>

--- a/app/code/community/HE/TwoFactorAuth/Model/Resource/Trusted.php
+++ b/app/code/community/HE/TwoFactorAuth/Model/Resource/Trusted.php
@@ -48,7 +48,18 @@ class HE_TwoFactorAuth_Model_Resource_Trusted extends Mage_Core_Model_Resource_D
     protected function addTokenCookie($token)
     {
         $cookie = Mage::getSingleton('core/cookie');
-        $cookie->set('he_tfa_trusted', $token ,31536000,'/');
+        $cookie->set('he_tfa_trusted', $token , $this->trustedHelper->getTrustedTime(), '/');
+    }
+
+    public function clearActivity($userId) {
+        $tfaCollection = Mage::getModel("he_twofactorauth/trusted")->getCollection()
+            ->addFieldToFilter("user_id", array("eq" => $userId));
+        if ($tfaCollection->count() >= 1) {
+            foreach ($tfaCollection as $tfa) {
+                $tfa->delete();
+            }
+        }
+        return $this;
     }
 
     public function findActivity()

--- a/app/code/community/HE/TwoFactorAuth/etc/config.xml
+++ b/app/code/community/HE/TwoFactorAuth/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <HE_TwoFactorAuth>
-            <version>1.1.11</version>
+            <version>1.1.12</version>
         </HE_TwoFactorAuth>
     </modules>
     <global>
@@ -117,6 +117,11 @@
                         <class>he_twofactorauth/observer</class>
                         <method>googleClearSecretCheck</method>
                     </he_twofactorauth_observer>
+                    <he_twofactorauth_observer_disable>
+                        <type>model</type>
+                        <class>he_twofactorauth/observer</class>
+                        <method>perUserTwoFactorCheck</method>
+                    </he_twofactorauth_observer_disable>
                 </observers>
             </adminhtml_block_html_before>
 
@@ -127,6 +132,11 @@
                         <class>he_twofactorauth/observer</class>
                         <method>googleSaveClear</method>
                     </he_twofactorauth_observer>
+                    <he_twofactorauth_observer_disable>
+                        <type>model</type>
+                        <class>he_twofactorauth/observer</class>
+                        <method>perUserTwoFactorDisable</method>
+                    </he_twofactorauth_observer_disable>
                 </observers>
             </model_save_before>
 
@@ -191,6 +201,7 @@
             </duo>
             <control>
                 <logaccess>1</logaccess>
+                <trusted_device_duration>2592000</trusted_device_duration>
             </control>
         </he2faconfig>
     </default>

--- a/app/code/community/HE/TwoFactorAuth/etc/system.xml
+++ b/app/code/community/HE/TwoFactorAuth/etc/system.xml
@@ -69,6 +69,22 @@
                             <show_in_website>1</show_in_website>
                         </trusted_device>
 
+                        <trusted_device_duration>
+                            <label>Trusted Device Duration</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>17</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <depends>
+                                <trusted_device>1</trusted_device>
+                            </depends>
+                            <comment>
+                                <![CDATA[
+                                    Duration in which you want to trust a device before having to Two Factor authenticate again.
+                                ]]>
+                            </comment>
+                        </trusted_device_duration>
+
                         <logaccess>
                             <label>Enable access logging</label>
                             <frontend_type>select</frontend_type>

--- a/app/code/community/HE/TwoFactorAuth/readme.txt
+++ b/app/code/community/HE/TwoFactorAuth/readme.txt
@@ -1,18 +1,19 @@
 # Sentry
-## Magento Two Factor Authentication Module
+## OpenMage Two Factor Authentication Module
 
 ### Authors
 - Greg Croasdill, Human Element, Inc http://www.human-element.com
 - Gregg Milligan, Human Element, Inc http://www.human-element.com
 - Aric Watson, Nexcess.net     https://www.nexcess.net/
+- Trevor Hartman, Hydrobuilder.com  https://hydrobuilder.com
 
 ### License  
 - GPL  -- https://www.gnu.org/copyleft/gpl.html
 
 ### Purpose
-Sentry Two-Factor Authentication will protect your Magento store and customer data by adding an extra check to authenticate
-your Admin users before allowing them access. Developed as a partnership between the Human Element Magento Development team
-and Nexcess Hosting, Sentry Two-Factor Authentication for Magento is easy to setup and admin users can quickly login.
+Sentry Two-Factor Authentication will protect your OpenMage store and customer data by adding an extra check to authenticate
+your Admin users before allowing them access. Developed as a partnership between the Human Element OpenMage Development team
+and Nexcess Hosting, Sentry Two-Factor Authentication for OpenMage is easy to setup and admin users can quickly login.
 
 ### Supported Providers (more to come)
 The following __Two Factor Authentication__ providers are supported at this time.
@@ -37,11 +38,12 @@ Some code based on previous work by Michael Kliewe/PHPGangsta
 
 ----
 ### Notes -
-1. Installing this module will update the AdminUser table in the Magento database to add a twofactor_google_secret
-field for storing the local GA key. It is safe to remove this field once the module is removed.
+1. Installing this module will update the AdminUser table in the OpenMage database to add a twofactor_google_secret and twofactor_disable
+fields for storing the local GA key and for disabling two factor on a per user basis respectively. It is safe to remove these fields
+once the module is removed.
 
 2. If you get locked out of admin because of a settings issue, loss of your provider account or other software related issue, you can *temporarily disable* the second factor authentication - 
- - Place a file named __tfaoff.flag__ in the root directory of your Magento installation.
- - Login to Magento's Admin area without the second factor.  
+ - Place a file named __tfaoff.flag__ in the root directory of your OpenMage installation.
+ - Login to OpenMage's Admin area without the second factor.  
  - Update settings or disable Sentry
  - Remove the tfaoff.flag file to re-enable two factor authentication.

--- a/app/code/community/HE/TwoFactorAuth/sql/he_twofactorauth/mysql4-upgrade-1.1.11-1.1.12.php
+++ b/app/code/community/HE/TwoFactorAuth/sql/he_twofactorauth/mysql4-upgrade-1.1.11-1.1.12.php
@@ -1,0 +1,16 @@
+<?php
+// create the  table on admin_user
+
+$installer = $this;
+$installer->startSetup();
+$installer->getConnection()
+    ->addColumn($installer->getTable('admin/user'),
+    'twofactor_disable',
+    array(
+        'type' => Varien_Db_Ddl_Table::TYPE_BOOLEAN,
+        'length' => 1,
+        'default' => null,
+        'comment' => 'Disable TwoFactor'
+    )
+);
+$installer->endSetup();


### PR DESCRIPTION
These changes include the following:

1. Addition of a configuration parameter in system.xml to allow setting the Trusted Device cookie expiration time.
2. Code that deletes Trusted device activity when a Google Auth Clear is performed to force Re-Auth even on trusted devices.
3. A new Admin User table column to allow per user opt-outs of performing two-factor authorization.
4. Update of readme.txt file to reference **OpenMage** instead of Magento 1 since **OpenMage** is the new LTS project for Magento 1.